### PR TITLE
Remove unneeded feature gates (stabilised in rust 1.3)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![feature(associated_consts)]
 #![feature(core_intrinsics)]
-#![feature(duration)]
-#![feature(thread_sleep)]
 #![feature(convert)]
 #![feature(core)]
 


### PR DESCRIPTION
The `duration` and `thread_sleep` features were stabilised in rust 1.3 so their feature gates are no longer needed.