### PR TITLE
Fix documentation URL in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Cuprum Pi is a GPIO access library written on Rust for the Raspberry Pi.
 
 *API Documentation*
 
-[doc](http://cuprumpi.github.io/cupi/cupi/index.html)
+[doc](http://inre.github.io/cupi/cupi/index.html)
 
 *Cross Compiling for Raspberry Pi*
 


### PR DESCRIPTION
The documentation URL currently available in the [README](README) seems to be broken.

* Old, broken: http://cuprumpi.github.io/cupi/cupi/index.html
* Should be: http://inre.github.io/cupi/cupi/index.html ([alternative](https://docs.rs/cupi/))

Here's a fix for that!